### PR TITLE
Update PolioPagerViewController.swift

### DIFF
--- a/PolioPager/PolioPagerViewController.swift
+++ b/PolioPager/PolioPagerViewController.swift
@@ -254,7 +254,6 @@ open class PolioPagerViewController: UIViewController, TabCellDelegate, PolioPag
         guard viewControllers.count == items.count
         else { fatalError("The number of ViewControllers must equal to the number of TabItems.") }
         
-        pageViewController.setPages(viewControllers)
         if needSearchTab {
             guard var searchTabViewController = viewControllers[0] as? PolioPagerSearchTabDelegate else { return }
             
@@ -262,6 +261,8 @@ open class PolioPagerViewController: UIViewController, TabCellDelegate, PolioPag
             searchTabViewController.searchBar = searchBar
             searchTabViewController.cancelButton = cancelButton
         }
+        
+        pageViewController.setPages(viewControllers)
     }
     
     private func setupAutoLayout() {


### PR DESCRIPTION
Is it possible to switch these lines? In my project PolioPager loads the SearchViewController before its properties (searchBar, searchTextField, cancelButton) are initialized.

This is because `PageViewController.nowIndex` will be set while `PageViewController.initialized` is true. In this case the SearchViewController will be initialized although the properties are not set yet.
`nowIndex` will be set when calling `PageViewController.setPages()`. And this call happens in `PolioPageViewController.setPages()` before `PolioPageViewController.needSearchTab` is checked and the SearchViewController properties were set.

I have no idea why this is. But switching these lines helps in my case.